### PR TITLE
Un-ignore test_tracetools

### DIFF
--- a/rolling.ignored
+++ b/rolling.ignored
@@ -1,2 +1,1 @@
-test_tracetools
 test_tracetools_launch


### PR DESCRIPTION
It is needed by ros2trace for now.